### PR TITLE
Fix managed-pool crash and harden email task

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
         tags=["email", "automation"],
         description="Sends scheduled emails to carers with payment information",
         job_variables={
-            "pip_packages": ["prefect-email"],
-            "env": {"EXTRA_PIP_PACKAGES": "prefect-email"},
+            "image": "prefecthq/prefect:3-python3.11",
+            "pip_packages": ["prefect-email>=0.4.2,<0.5"],
         },
     )

--- a/email_flow.py
+++ b/email_flow.py
@@ -111,7 +111,8 @@ def example_email_send_message_flow(email_addresses: List[str]):
         for carer_name, carer_config in carers.items():
             logger.info(f"Sending email for {carer_name}")
             subject = email_send_message.with_options(
-                name=f"email {email_address} - {carer_name}"
+                name=f"email {email_address} - {carer_name}",
+                timeout_seconds=150,
             ).submit(
                 email_server_credentials=email_server_credentials,  # type: ignore
                 subject=email_subject(carer_name),


### PR DESCRIPTION
 ## Summary                                   
  - Switch managed work pool runtime from the default slim `prefect-client:3-latest`              
    image to the full `prefecthq/prefect:3-python3.11` image, and pin                               
    `prefect-email>=0.4.2,<0.5`. The slim image plus unpinned `prefect-email` caused              
    a namespace collision when `prefect-email` transitively pulled in full `prefect`,               
    killing the worker at startup before any logs were emitted (run appeared as
    Crashed only after the 24h+ heartbeat sweep).                                                   
  - Add `timeout_seconds=150` to the `email_send_message` task so a hung SMTP
    connection can't silently swallow a flow run.                                                   
                                                                                                  
  ## Test plan                                                                                      
  - [x] `uv run pytest tests/ -v` — all 10 tests pass                                             
  - [x] `uv run python deploy.py` — deployment re-applied to Prefect Cloud                          
  - [x] Triggered run on managed pool — completed in ~3s with all logs visible                    
  - [X] Reviewer: confirm next scheduled run (`0 8 12 * *`) succeeds on the managed pool